### PR TITLE
Fix frontend volume mounting in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       REACT_APP_WS_URL: ${REACT_APP_WS_URL:-wss://api.solarnexus.com}
       REACT_APP_ENVIRONMENT: production
     volumes:
-      - frontend_build:/app/dist
+      - frontend_build:/usr/share/nginx/html
     networks:
       - solarnexus-network
     depends_on:


### PR DESCRIPTION
## Problem
The frontend container was mounting `/app/dist` to the `frontend_build` volume, but the built files are actually located at `/usr/share/nginx/html` in the production stage of the Dockerfile. This caused nginx to serve 403 errors because it couldn't access the frontend static files.

## Solution
- Fixed the volume mount path from `/app/dist` to `/usr/share/nginx/html` in the frontend service
- This ensures the built React files are properly shared between the frontend and nginx containers

## Testing
- ✅ All SolarNexus services now start successfully
- ✅ Frontend is accessible at `http://localhost/`
- ✅ Backend API health check works at `http://localhost:3000/health`
- ✅ Nginx health check works at `http://localhost/health`

## Services Status
- **PostgreSQL Database** (port 5432) - ✅ Healthy
- **Redis Cache** (port 6379) - ✅ Healthy  
- **Backend API** (port 3000) - ✅ Healthy
- **Frontend React App** - ✅ Running
- **Nginx Reverse Proxy** (port 80) - ✅ Healthy

@Reshigan can click here to [continue refining the PR](https://app.all-hands.dev/conversations/66cd32ba7d5c4dd3afe27492f1c9342b)